### PR TITLE
Colocar script al final de body

### DIFF
--- a/DavidCubillos/index.html
+++ b/DavidCubillos/index.html
@@ -19,14 +19,7 @@
 
 <!--[if IE]><style type="text/css">.pie {behavior:url(PIE.htc);}</style><![endif]-->
 
-<script type="text/javascript" src="js/jquery.1.8.3.min.js"></script>
-<script type="text/javascript" src="js/bootstrap.js"></script>
-<script type="text/javascript" src="js/jquery-scrolltofixed.js"></script>
-<script type="text/javascript" src="js/jquery.easing.1.3.js"></script>
-<script type="text/javascript" src="js/jquery.isotope.js"></script>
-<script type="text/javascript" src="js/wow.js"></script>
-<script type="text/javascript" src="js/classie.js"></script>
-
+<!--Andrea-Paredes: Es mejor colocar los script al final del body.-->
 
 <!--[if lt IE 9]>
     <script src="js/respond-1.1.0.min.js"></script>
@@ -112,7 +105,13 @@
     -->
 </footer>
 
-
+<script type="text/javascript" src="js/jquery.1.8.3.min.js"></script>
+<script type="text/javascript" src="js/bootstrap.js"></script>
+<script type="text/javascript" src="js/jquery-scrolltofixed.js"></script>
+<script type="text/javascript" src="js/jquery.easing.1.3.js"></script>
+<script type="text/javascript" src="js/jquery.isotope.js"></script>
+<script type="text/javascript" src="js/wow.js"></script>
+<script type="text/javascript" src="js/classie.js"></script>
 <script type="text/javascript">
     $(document).ready(function(e) {
         $('#test').scrollToFixed();


### PR DESCRIPTION
Así se evita que el navegador se tarde mucho cargando la página, puesto que primero realizaría las 
peticiones para obtener los archivos de los script y después cargaría el resto de la página.